### PR TITLE
add role binding template

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,0 +1,28 @@
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    name: "cns-obj-broker"
+    namespace: "default"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: "cns-obj-broker"
+  subjects:
+  - kind: ServiceAccount
+    apiGroup: ""
+    name: "default"
+    namespace: "{{ .Release.Namespace }}"
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  metadata:
+    name: "cns-obj-broker"
+    namespace: "default"
+  rules:
+  - apiGroups: [""]
+    resources: ["services", "pods"]
+    verbs: ["get", "list", "watch"]
+{{ end }}


### PR DESCRIPTION
Adds RBAC compliance for cns-broker to allow for list,watch,get of pods and services in the `default` namespace